### PR TITLE
Fix scrolling error on console because of passive event

### DIFF
--- a/src/event-handler.ts
+++ b/src/event-handler.ts
@@ -26,9 +26,7 @@ export class GEEventHandler {
     });
     window.addEventListener("keydown", this.handleKeyDown, { passive: true });
     window.addEventListener("keyup", this.handleKeyUp, { passive: true });
-    this.canvas.addEventListener("wheel", this.handleCanvasWheel, {
-      passive: true
-    });
+    this.canvas.addEventListener("wheel", this.handleCanvasWheel);
   }
 
   destroy(): void {


### PR DESCRIPTION
Removes `passive: true` option from scroll event.